### PR TITLE
Fixed selection algorithm

### DIFF
--- a/mlm/app/tasks.py
+++ b/mlm/app/tasks.py
@@ -57,8 +57,9 @@ class Tasks(object):
                                if m.id != previous_leader.id]
 
                 choices = []
+                max_score = max(m.leader_score for m in members) + 1
                 for m in members:
-                    weight = len(members) - m.leader_score % len(members)
+                    weight = max_score - m.leader_score
                     # lets increase the difference between weights
                     weight *= 10
                     choices.append((m, weight))


### PR DESCRIPTION
Previous algorithm for member score was:

   weight = len(members) - m.leader_score % len(members)

So for example we have 10 members:
9 of them has score 9 and the last of the has score 100.
In this case 9 members will get weigh 1 and the last member
will get weigh 10. It's incorrect.

The algorithm will simply subtract current member score
from the max score to get weigh. This fix will make selection more smooth.